### PR TITLE
enabledRemoteNotificationTypes is deprecated in iOS8+

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -283,7 +283,12 @@
   [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
   
   // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-  NSUInteger rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+  NSUInteger rntypes;
+  #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+      rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types]; 
+  #else
+      rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes]; 
+  #endif
   
   // Set the defaults to disabled unless we find otherwise...
   NSString *pushBadge = @"disabled";


### PR DESCRIPTION
The **enabledRemoteNotificationTypes** method is deprected for iOS8+, so using **currentUserNotificationSettings** instead
