### PR TITLE
Fix missing inclusion of bb10 plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,6 +71,19 @@
 
 	</platform>
 
+	<!-- blackberry10 -->
+	<platform name="blackberry10">
+		<dependency id="com.blackberry.app" />
+		<dependency id="com.blackberry.push" />
+		<dependency id="com.blackberry.invoked" />
+		<config-file target="www/config.xml" parent="/widget">
+			<feature name="PushPlugin" value="PushPlugin" />
+		</config-file>
+		<js-module src="www/blackberry10/PushPluginProxy.js" name="PushPluginProxy" >
+			<runs />
+		</js-module>
+	</platform>
+
 	<!-- ios -->
 	<platform name="ios">
 


### PR DESCRIPTION
I'm not sure if I was just missing something, but the plugin wouldn't work for me without this addition, which I took from our own fork.
