### PR TITLE
Call error callback when service is available

### DIFF
--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -171,6 +171,7 @@ public class PushPlugin extends CordovaPlugin {
 				callbackContext[0].success(regid);
 			} catch (Exception ex) {
 				Log.d(TAG, "Got Exception on registerInBackground", ex);
+				callbackContext[0].error(ex.getMessage());
 			}
 			return null;
 		}


### PR DESCRIPTION
This patch fixes the following issue:

When the cordova app starts on the phone with Airplane mode ON the plugin's register method do not call any callback.

`logcat` contains these messages:

```
PushPlugin: Got Exception on registerInBackground
java.io.IOException: SERVICE_NOT_AVAILABLE
```

With this patch the plugin calls the error callback when this exception happens.
